### PR TITLE
fix(openapi): multi-level group route `.openapi()` parsing

### DIFF
--- a/.changeset/neat-planets-dance.md
+++ b/.changeset/neat-planets-dance.md
@@ -1,0 +1,5 @@
+---
+'@tuyau/openapi': patch
+---
+
+Fixed multi-level group route `.openapi()` parsing.

--- a/packages/openapi/src/bindings/routes.ts
+++ b/packages/openapi/src/bindings/routes.ts
@@ -31,7 +31,7 @@ export function registerRouteMacros(metaStore: MetaStore) {
   )
 
   RouteGroup.macro('openapi', function (this: RouteGroup, detail: OpenAPIV3_1.OperationObject) {
-    this.routes.forEach((route) => {
+    function handleAnyRouteType(route: Route | RouteGroup | RouteResource | BriskRoute) {
       if (route instanceof Route) {
         metaStore.set(route, { ...detail, ...metaStore.get(route) })
       } else if (route instanceof RouteResource) {
@@ -40,7 +40,15 @@ export function registerRouteMacros(metaStore: MetaStore) {
         )
       } else if (route instanceof BriskRoute) {
         metaStore.set(route.route!, { ...detail, ...metaStore.get(route.route!) })
+      } else if (route instanceof RouteGroup) {
+        route.routes.forEach((route) => {
+          handleAnyRouteType(route)
+        })
       }
+    }
+
+    this.routes.forEach((route) => {
+      handleAnyRouteType(route)
     })
     return this
   })


### PR DESCRIPTION
Consider the following contents of the `start/routes.ts` file:

```typescript
router.group(() => {
  router.group(() => {
    router.get("/foo")
      .openapi({  // OpenAPI options of actual route (3rd level)
        responses: {
          "403": {
            ...
          },
        },
      });
  }).openapi({  // OpenAPI options of 2nd level group
    responses: {
      "402": {
        ...
      },
    },
  });
}).openapi({  // OpenAPI options of 1st level group
  responses: {
    "401": {
      ...
    },
  },
});
```

For readability, the above routes can be viewed in POV of HTML tags as:

```html
<Group openapi={{ responses: { '401': ... } }}>
     <Group openapi={{ responses: { '402': ... } }}>
         <Route get="/foo" openapi={{ responses: { '403': ... } }} />
     </Group>
 </Group>
```

Previously, the `openapi` options of the 1st level group was ignored i.e. `401` response. So only `402` and `403` responses were parsed.

This PR fixes the above bug for any group route level by using recursive function to parse group routes.