### PR TITLE
feat: Override errors types globally

### DIFF
--- a/packages/core/src/backend/registry_generator.ts
+++ b/packages/core/src/backend/registry_generator.ts
@@ -12,13 +12,17 @@ const DEFAULT_VALIDATION_ERROR_TYPE = '{ errors: SimpleError[] }'
  */
 export class RegistryGenerator {
   #validationErrorType: string | false
+  #errorResponseType?: string
   #routesFilter?: GenerateRegistryConfig['routes']
 
-  constructor(options?: Partial<Pick<GenerateRegistryConfig, 'validationErrorType' | 'routes'>>) {
+  constructor(
+    options?: Partial<Pick<GenerateRegistryConfig, 'validationErrorType' | 'errorResponseType' | 'routes'>>,
+  ) {
     this.#validationErrorType =
       options?.validationErrorType === undefined
         ? DEFAULT_VALIDATION_ERROR_TYPE
         : options.validationErrorType
+    this.#errorResponseType = options?.errorResponseType
     this.#routesFilter = options?.routes
   }
 
@@ -226,9 +230,9 @@ export class RegistryGenerator {
     const responseType = this.#wrapResponseType(rawResponseType)
     const hasValidator = requestType !== '{}'
 
-    let errorResponseType = this.#wrapErrorResponseType(rawResponseType)
+    let errorResponseType = this.#errorResponseType ?? this.#wrapErrorResponseType(rawResponseType)
 
-    if (hasValidator && this.#validationErrorType !== false) {
+    if (hasValidator && this.#validationErrorType !== false && !this.#errorResponseType) {
       const validationError = `{ status: 422; response: ${this.#validationErrorType} }`
       errorResponseType =
         errorResponseType === 'unknown'

--- a/packages/core/src/backend/types.ts
+++ b/packages/core/src/backend/types.ts
@@ -85,4 +85,10 @@ export interface GenerateRegistryConfig {
    * Set to `false` to disable auto-adding 422 errors.
    */
   validationErrorType?: string | false
+
+  /**
+   * Custom TypeScript type string used as the error response type for all routes.
+   * When not provided, error response types are inferred from each route response.
+   */
+  errorResponseType?: string
 }

--- a/packages/core/tests/generate_registry.spec.ts
+++ b/packages/core/tests/generate_registry.spec.ts
@@ -107,6 +107,41 @@ test.group('generateTypesContent | validation error injection', () => {
     assert.include(content, 'errorResponse: unknown')
   })
 
+  test('supports global errorResponseType override for all routes', ({ assert }) => {
+    const routes = [
+      makeRoute({
+        name: 'users.store',
+        methods: ['POST'],
+        pattern: '/users',
+        request: { type: 'InferInput<typeof createUserValidator>', imports: [] },
+        response: { type: "ReturnType<UsersController['store']>", imports: [] },
+      }),
+    ]
+
+    const generator = new RegistryGenerator({ errorResponseType: '{ status: number, code: string, payload?: unknown}' })
+    const content = generator.generateTypesContent(routes)
+
+    assert.include(content, 'errorResponse: { status: number, code: string, payload?: unknown} | { status: 422; response: { errors: SimpleError[] } }')
+    assert.notInclude(content, "ExtractErrorResponse<Awaited<ReturnType<UsersController['store']>>>")
+  })
+
+  test('global errorResponseType override applies to routes without validators', ({ assert }) => {
+    const routes = [
+      makeRoute({
+        name: 'home',
+        methods: ['GET'],
+        pattern: '/',
+        response: { type: 'unknown', imports: [] },
+      }),
+    ]
+
+    const generator = new RegistryGenerator({ errorResponseType: '{ status: number, code: string, payload?: unknown}' })
+    const content = generator.generateTypesContent(routes)
+
+    assert.include(content, 'errorResponse: { status: number, code: string, payload?: unknown}')
+    assert.notInclude(content, '422')
+  })
+
   test('imports SimpleError from vine only when using default type', ({ assert }) => {
     const routes = [
       makeRoute({


### PR DESCRIPTION
This PR add a GenerateRegistry parameter to override the Errors types instead of infer it from all routes

Example usage:
```typescript
      generateRegistry({
        errorResponseType: '{ error: { status: number; code: string; payload?: unknown } }'
      }),
```